### PR TITLE
Fix swagger path for jobDescription

### DIFF
--- a/src/routes/jobDescription.routes.js
+++ b/src/routes/jobDescription.routes.js
@@ -69,7 +69,7 @@ jobDescriptionRoutes.post(
 
 /**
  * @swagger
- * /api/jobDecriptions/loopAndCreate:
+ * /api/jobDescriptions/loopAndCreate:
  *   post:
  *     tags:
  *       - Job Description

--- a/src/schemas/openapi.json
+++ b/src/schemas/openapi.json
@@ -321,7 +321,7 @@
         }
       }
     },
-    "/api/jobDecriptions/loopAndCreate": {
+    "/api/jobDescriptions/loopAndCreate": {
       "post": {
         "tags": [
           "Job Description"


### PR DESCRIPTION
## Summary
- correct `/loopAndCreate` path in `jobDescription.routes.js`
- update generated `openapi.json` path

## Testing
- `npm run schemas:openapi` *(fails: swagger-jsdoc not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685223847480832d956b273d161d070f