### PR TITLE
Fix asynchronous keyword association

### DIFF
--- a/src/services/job.services.js
+++ b/src/services/job.services.js
@@ -174,9 +174,12 @@ export const bulkCreateJobs = async (jobs, keyword) => {
       },
     });
     const newJobs = await Job.bulkCreate(jobs, { ignoreDuplicates: true });
-    await newJobs.forEach(async (job) => {
-      await job.addKeyword(keywordInstance);
-    });
+    // Ensure all keyword associations are created before returning
+    await Promise.all(
+      newJobs.map(async (job) => {
+        await job.addKeyword(keywordInstance);
+      })
+    );
     return newJobs;
   } catch (error) {
     console.log("🚀 ~ bulkCreateJobs ~ error:", error);


### PR DESCRIPTION
## Summary
- fix bulkCreateJobs keyword association to await each job's update

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850be330694832db508bcde128ec549