### PR TITLE
Fix nodemon configuration

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -2,5 +2,5 @@
   "watch": ["src"],
   "ext": "js,ts,mjs,json",
   "ignore": ["node_modules"],
-  "exec": "node src/index.ts"
+  "exec": "ts-node src/index.ts"
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "the-hire-me-project",
   "version": "1.0.0",
-  "main": "src/index.ts",
-  "type": "module",
+  "main": "dist/index.js",
+  "type": "commonjs",
   "scripts": {
     "test": "jest",
-    "start": "nodemon src/index.ts",
+    "start": "nodemon",
     "schemas:openapi": "swagger-jsdoc -d src/routes/definition.yaml src/routes/**/*.js src/routes/**/*.yaml \"src/routes/!(definition).yaml\" -o src/schemas/openapi.json",
     "prepare": "husky install",
     "build": "tsc"
@@ -55,6 +55,7 @@
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
     "typescript": "^5.4.5",
-    "typescript-eslint": "^8.6.0"
+    "typescript-eslint": "^8.6.0",
+    "ts-node": "^10.9.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2021",
-    "module": "ESNext",
+    "module": "CommonJS",
     "moduleResolution": "node",
     "allowJs": true,
     "checkJs": false,


### PR DESCRIPTION
## Summary
- configure nodemon to run `ts-node`
- use CommonJS module format and adjust main entry
- add `ts-node` to dev dependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853b6d9ac5c832d8ac744f5051c6479