### PR TITLE
Add user-related join tables

### DIFF
--- a/src/models/UserExclusion.ts
+++ b/src/models/UserExclusion.ts
@@ -1,0 +1,28 @@
+import { Model, DataTypes } from "sequelize";
+import db from "../db/connection.js";
+
+export default class UserExclusion extends Model {}
+
+UserExclusion.init(
+  {
+    id: {
+      autoIncrement: true,
+      allowNull: false,
+      unique: true,
+      primaryKey: true,
+      type: DataTypes.INTEGER,
+    },
+    userId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    exclusionId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+  },
+  {
+    tableName: "userExclusions",
+    sequelize: db,
+  }
+);

--- a/src/models/UserJob.ts
+++ b/src/models/UserJob.ts
@@ -1,0 +1,28 @@
+import { Model, DataTypes } from "sequelize";
+import db from "../db/connection.js";
+
+export default class UserJob extends Model {}
+
+UserJob.init(
+  {
+    id: {
+      autoIncrement: true,
+      allowNull: false,
+      unique: true,
+      primaryKey: true,
+      type: DataTypes.INTEGER,
+    },
+    userId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    jobId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    tableName: "userJobs",
+    sequelize: db,
+  }
+);

--- a/src/models/UserSkill.ts
+++ b/src/models/UserSkill.ts
@@ -1,0 +1,28 @@
+import { Model, DataTypes } from "sequelize";
+import db from "../db/connection.js";
+
+export default class UserSkill extends Model {}
+
+UserSkill.init(
+  {
+    id: {
+      autoIncrement: true,
+      allowNull: false,
+      unique: true,
+      primaryKey: true,
+      type: DataTypes.INTEGER,
+    },
+    userId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    skillId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+  },
+  {
+    tableName: "userSkills",
+    sequelize: db,
+  }
+);

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -3,6 +3,12 @@ import JobDescription from "./JobDescription.js";
 import CoverLetter from "./CoverLetter.js";
 import Keyword from "./Keyword.js";
 import JobKeyword from "./JobKeyword.js";
+import User from "./User.js";
+import Skill from "./Skill.js";
+import Exclusion from "./Exclusion.js";
+import UserJob from "./UserJob.js";
+import UserSkill from "./UserSkill.js";
+import UserExclusion from "./UserExclusion.js";
 
 Job.hasOne(JobDescription, { foreignKey: "id" });
 JobDescription.belongsTo(Job, { foreignKey: "id" });
@@ -13,9 +19,26 @@ JobDescription.belongsTo(Job, { foreignKey: "id" });
 Job.belongsToMany(Keyword, { through: JobKeyword, foreignKey: "jobId", otherKey: "keywordId" });
 Keyword.belongsToMany(Job, { through: JobKeyword, foreignKey: "keywordId", otherKey: "jobId" });
 
+User.belongsToMany(Job, { through: UserJob, foreignKey: "userId", otherKey: "jobId" });
+Job.belongsToMany(User, { through: UserJob, foreignKey: "jobId", otherKey: "userId" });
+
+User.belongsToMany(Skill, { through: UserSkill, foreignKey: "userId", otherKey: "skillId" });
+Skill.belongsToMany(User, { through: UserSkill, foreignKey: "skillId", otherKey: "userId" });
+
+User.belongsToMany(Exclusion, { through: UserExclusion, foreignKey: "userId", otherKey: "exclusionId" });
+Exclusion.belongsToMany(User, { through: UserExclusion, foreignKey: "exclusionId", otherKey: "userId" });
+
 Job.hasOne(CoverLetter, { foreignKey: "id" });
 CoverLetter.belongsTo(Job, { foreignKey: "id" });
 // Job.hasOne(CoverLetter, { foreignKey: 'jobId' });
 // CoverLetter.belongsTo(Job, { foreignKey: 'jobId' });
 
-export { Job, JobDescription, CoverLetter, Keyword };
+export {
+  Job,
+  JobDescription,
+  CoverLetter,
+  Keyword,
+  User,
+  Skill,
+  Exclusion,
+};


### PR DESCRIPTION
## Summary
- add join tables `UserJob`, `UserSkill`, and `UserExclusion`
- register `belongsToMany` relations for these tables in the model index

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b89540b9c832d9e744a04f40e4938