### PR TITLE
Fix FK creation in job keywords

### DIFF
--- a/src/services/job.services.ts
+++ b/src/services/job.services.ts
@@ -395,6 +395,10 @@ export const addKeywordToJob = async (
     },
     transaction,
   });
-  await jobKeywordService.createJobKeyword(jobId, newKeyword.dataValues.id);
+  await jobKeywordService.createJobKeyword(
+    jobId,
+    newKeyword.dataValues.id,
+    transaction
+  );
   return job;
 };

--- a/src/services/jobKeyword.services.ts
+++ b/src/services/jobKeyword.services.ts
@@ -1,8 +1,16 @@
 import JobKeyword from "../models/JobKeyword.js";
+import { Transaction } from "sequelize";
 
-export const createJobKeyword = async (jobId: string, keywordId: number) => {
+export const createJobKeyword = async (
+  jobId: string,
+  keywordId: number,
+  transaction?: Transaction
+) => {
   try {
-    const jobKeyword = await JobKeyword.create({ jobId, keywordId });
+    const jobKeyword = await JobKeyword.create(
+      { jobId, keywordId },
+      { transaction }
+    );
     return jobKeyword;
   } catch (error) {
     console.error("Error creating JobKeyword:", error);


### PR DESCRIPTION
## Summary
- pass transaction when creating JobKeyword records
- ensure addKeywordToJob forwards the transaction

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: various TS errors due to missing types)*

------
https://chatgpt.com/codex/tasks/task_e_6865cc0c6e5c832d949529a26b92b50c